### PR TITLE
Fix Riverpod overrides and router refresh handling

### DIFF
--- a/lib/app/bootstrap.dart
+++ b/lib/app/bootstrap.dart
@@ -5,7 +5,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:riverpod/riverpod.dart' show ProviderOverride;
 
 import 'package:app_management/app/app.dart';
 import 'package:app_management/app/di/providers.dart';
@@ -15,7 +14,7 @@ import 'package:app_management/core/storage/hive_manager.dart';
 import 'package:app_management/core/utils/logger.dart';
 import 'package:app_management/features/example_todos/infrastructure/models/todo_dto.dart';
 
-Future<void> bootstrap({AppConfig? config, List<ProviderOverride> overrides = const <ProviderOverride>[], Widget? rootWidget}) async {
+Future<void> bootstrap({AppConfig? config, List<Override> overrides = const <Override>[], Widget? rootWidget}) async {
   WidgetsFlutterBinding.ensureInitialized();
   final resolvedConfig = config ?? AppConfig.fromEnvironment();
   final logger = AppLogger(config: resolvedConfig);
@@ -27,7 +26,7 @@ Future<void> bootstrap({AppConfig? config, List<ProviderOverride> overrides = co
   await hiveManager.openCoreBoxes();
 
   final container = ProviderContainer(
-    overrides: <ProviderOverride>[
+    overrides: <Override>[
       appConfigProvider.overrideWithValue(resolvedConfig),
       hiveManagerProvider.overrideWithValue(hiveManager),
       ...overrides,

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -15,8 +15,7 @@ import 'package:app_management/features/settings/presentation/screens/settings_p
 
 final routerProvider = Provider<GoRouter>((ref) {
   final guard = AuthGuard(ref);
-  final notifier = ref.read(authNotifierProvider.notifier);
-  final refreshListenable = StreamRouterRefreshListenable(notifier.stream);
+  final refreshListenable = ProviderRouterRefreshListenable(ref, authNotifierProvider);
   final router = GoRouter(
     initialLocation: TodosRoute.location,
     routes: <RouteBase>[
@@ -97,15 +96,20 @@ class SettingsRoute {
   static void go(BuildContext context) => context.go(location);
 }
 
-class StreamRouterRefreshListenable extends ChangeNotifier {
-  StreamRouterRefreshListenable(Stream<dynamic> stream)
-      : _subscription = stream.listen((_) => notifyListeners());
+class ProviderRouterRefreshListenable extends ChangeNotifier {
+  ProviderRouterRefreshListenable(Ref ref, ProviderListenable<dynamic> listenable) {
+    _subscription = ref.listen<dynamic>(
+      listenable,
+      (_, __) => notifyListeners(),
+      fireImmediately: false,
+    );
+  }
 
-  final StreamSubscription<dynamic> _subscription;
+  late final ProviderSubscription<dynamic> _subscription;
 
   @override
   void dispose() {
-    _subscription.cancel();
+    _subscription.close();
     super.dispose();
   }
 }

--- a/test/app/auth_guard_test.dart
+++ b/test/app/auth_guard_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:riverpod/riverpod.dart' show ProviderOverride;
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
 
@@ -29,7 +28,7 @@ void main() {
     when(repository.currentUser).thenAnswer((_) async => null);
     // ignore: lines_longer_than_80_chars
     final container = ProviderContainer(
-      overrides: <ProviderOverride>[authRepositoryProvider.overrideWithValue(repository)],
+      overrides: <Override>[authRepositoryProvider.overrideWithValue(repository)],
     );
     addTearDown(container.dispose);
     await container.read(authNotifierProvider.future);
@@ -49,7 +48,7 @@ void main() {
     final user = const AuthUser(id: '1', email: 'test@test.com');
     when(repository.currentUser).thenAnswer((_) async => user);
     final container = ProviderContainer(
-      overrides: <ProviderOverride>[authRepositoryProvider.overrideWithValue(repository)],
+      overrides: <Override>[authRepositoryProvider.overrideWithValue(repository)],
     );
     addTearDown(container.dispose);
     await container.read(authNotifierProvider.future);

--- a/test/features/auth/auth_notifier_test.dart
+++ b/test/features/auth/auth_notifier_test.dart
@@ -7,7 +7,6 @@ import 'package:app_management/features/auth/domain/repositories/auth_repository
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:riverpod/riverpod.dart' show ProviderOverride;
 
 class _MockAuthRepository extends Mock implements AuthRepository {}
 
@@ -18,7 +17,7 @@ void main() {
   setUp(() {
     repository = _MockAuthRepository();
     container = ProviderContainer(
-      overrides: <ProviderOverride>[authRepositoryProvider.overrideWithValue(repository)],
+      overrides: <Override>[authRepositoryProvider.overrideWithValue(repository)],
     );
   });
 

--- a/test/features/example_todos/todos_notifier_test.dart
+++ b/test/features/example_todos/todos_notifier_test.dart
@@ -9,7 +9,6 @@ import 'package:app_management/features/example_todos/domain/repositories/todo_r
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:riverpod/riverpod.dart' show ProviderOverride;
 
 class _MockTodoRepository extends Mock implements TodoRepository {}
 
@@ -21,7 +20,7 @@ void main() {
     repository = _MockTodoRepository();
     when(repository.watchTodos).thenAnswer((_) => const Stream<List<Todo>>.empty());
     container = ProviderContainer(
-      overrides: <ProviderOverride>[todoRepositoryProvider.overrideWithValue(repository)],
+      overrides: <Override>[todoRepositoryProvider.overrideWithValue(repository)],
     );
   });
 


### PR DESCRIPTION
## Summary
- replace deprecated `ProviderOverride` usages with the correct `Override` type in bootstrap and tests
- update router refresh logic to listen to the auth notifier provider via a reusable `ProviderRouterRefreshListenable`

## Testing
- not run (Flutter/Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db893351e0832baa64f076a7c8bc55